### PR TITLE
Pin `pyparsing` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     description="filtration - A library for parsing arbitrary filters",
     long_description=long_description,
     install_requires=[
-        "pyparsing",
+        "pyparsing<3.0.0",
         "ipcalc"
     ],
     classifiers=[


### PR DESCRIPTION
`pyparsing`'s API has changed in 3.0.0 and some needed features have been depreciated:

For instance it has removed the `operatorPrecedence` synonym for `infixNotation`.
Also many of the `camelCase` names are soon to be changed to `snake_case`.
To ensure we're not hit by more changes pin the version lower until the codebase
can be update fully to be compatible with >= `3.0.0`