### PR TITLE
Allow for literal dots in keys

### DIFF
--- a/filtration/__init__.py
+++ b/filtration/__init__.py
@@ -78,6 +78,11 @@ Subnet = Combine(IpAddr + "/" + Cidr).set_parse_action(_Subnet)
 
 class _Symbol(Token):
     def __call__(self, ctx):
+        # If symbol is a literal 'a.b' and exists in ctx, return it
+        # Imperfect bugfix to allow for fields with literal dots in the root of ctx
+        if self.value in ctx:
+            return ctx[self.value]
+
         parts = self.value.split(".")
         value = ctx
         for part in parts:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-VERSION = "2.3.1"
+VERSION = "2.3.2"
 
 
 with open("README.rst", "r") as f:


### PR DESCRIPTION
Allows for keys with literal dots to be matched, if they are in the root of a dictionary. This is an imperfect fix as it doesn't handle similar keys if they are nested, but this is enough for our uses. 